### PR TITLE
Remove deprecated taps

### DIFF
--- a/rich-demo/modules/apps.nix
+++ b/rich-demo/modules/apps.nix
@@ -54,9 +54,7 @@
     };
 
     taps = [
-      "homebrew/cask-fonts"
       "homebrew/services"
-      "homebrew/cask-versions"
     ];
 
     # `brew install`


### PR DESCRIPTION
```
Tapping homebrew/cask-versions
Error: homebrew/cask-versions was deprecated. This tap is now empty and all its contents were either deleted or migrated.
Tapping homebrew/cask-versions has failed!

Tapping homebrew/cask-fonts
Error: homebrew/cask-fonts was deprecated. This tap is now empty and all its contents were either deleted or migrated.
Tapping homebrew/cask-fonts has failed!
```