### PR TITLE
Remove deprecated taps from minimal

### DIFF
--- a/minimal/modules/apps.nix
+++ b/minimal/modules/apps.nix
@@ -1,12 +1,12 @@
 { pkgs, ...}: {
 
   ##########################################################################
-  # 
+  #
   #  Install all apps and packages here.
   #
   #  NOTE: Your can find all available options in:
   #    https://daiderd.com/nix-darwin/manual/index.html
-  # 
+  #
   # TODO Fell free to modify this file to fit your needs.
   #
   ##########################################################################
@@ -22,7 +22,7 @@
   ];
 
   # TODO To make this work, homebrew need to be installed manually, see https://brew.sh
-  # 
+  #
   # The apps installed by homebrew are not managed by nix, and not reproducible!
   # But on macOS, homebrew has a much larger selection of apps than nixpkgs, especially for GUI apps!
   homebrew = {
@@ -35,9 +35,7 @@
     };
 
     taps = [
-      "homebrew/cask-fonts"
       "homebrew/services"
-      "homebrew/cask-versions"
     ];
 
     # `brew install`


### PR DESCRIPTION
They were removed from ```rich-demo```, but not ```minimal``` in #10. 