### PR TITLE
Fix issue with zsh program in rich-demo

### DIFF
--- a/rich-demo/home/shell.nix
+++ b/rich-demo/home/shell.nix
@@ -2,7 +2,7 @@
   programs.zsh = {
     enable = true;
     enableCompletion = true;
-    bashrcExtra = ''
+    initExtra = ''
       export PATH="$PATH:$HOME/bin:$HOME/.local/bin:$HOME/go/bin"
     '';
   };


### PR DESCRIPTION
The config ```bashrcExtra``` does not exist for zsh - should be ```initExtra```