### PR TITLE
fix: move default Justfile recipe to top

### DIFF
--- a/rich-demo/Justfile
+++ b/rich-demo/Justfile
@@ -3,6 +3,10 @@
 # TODO update hostname here!
 hostname := "your-hostname"
 
+# List all the just commands
+default:
+  @just --list
+
 ############################################################################
 #
 #  Darwin related commands
@@ -33,10 +37,6 @@ darwin-debug: darwin-set-proxy
 #  nix related commands
 #
 ############################################################################
-
-# List all the just commands
-default:
-    @just --list
 
 # Update all the flake inputs
 [group('nix')]


### PR DESCRIPTION
First of all: thank you for your work! Thanks to this repository, I have finally succeeded in achieving a configuration that suits my needs.

Doing so, I stumbled upon the fact that the default recipe in the `Justfile` didn't work. After reading the [documentation](https://github.com/casey/just?tab=readme-ov-file#the-default-recipe) of `just`, it turns out that the default recipe needs to be at the top, so this PR does exactly that.